### PR TITLE
upgpkg: heroku-cli 7.38.1

### DIFF
--- a/heroku-cli/.SRCINFO
+++ b/heroku-cli/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = heroku-cli
 	pkgdesc = a tool for creating and managing Heroku apps from the command line
-	pkgver = 7.36.3
+	pkgver = 7.38.1
 	pkgrel = 1
 	url = https://devcenter.heroku.com/articles/heroku-cli
 	arch = x86_64
@@ -12,11 +12,11 @@ pkgbase = heroku-cli
 	conflicts = heroku-client-standalone
 	conflicts = heroku-toolbelt
 	conflicts = ruby-heroku
-	noextract = heroku-7.36.3.tgz
+	noextract = heroku-7.38.1.tgz
 	options = !strip
-	source = https://registry.npmjs.org/heroku/-/heroku-7.36.3.tgz
-	sha256sums = 2f55c1482fd0a195ce3ab3e65547910069543bf6f59c3033e8dc775174ed88fb
-	sha512sums = 14112ae52eb58ff98285dd6b4bf1117af7ad981b33fd9c26af58733848ae0f4f4c2047a72bbc6414d5a07c7f17c97eacbefa9a459714c6a7511e5e72b797943d
+	source = https://registry.npmjs.org/heroku/-/heroku-7.38.1.tgz
+	sha256sums = 2ddbc5c53fbb114897bcc0008a11bd8f2abcc744d0365f1c4a77f199b1bda9d5
+	sha512sums = 655e8b1d45d36deddbd2ef1c10307fed26678d45f3d3fb2531f9997cf4413211b0e0e1a3b1ca61a0cacb030ceb6df1dff171551feaba7cc7077f203b594d8ff8
 
 pkgname = heroku-cli
 

--- a/heroku-cli/PKGBUILD
+++ b/heroku-cli/PKGBUILD
@@ -2,7 +2,7 @@
 # Contributor: Rhys Kenwell <redrield+aur@gmail.com>
 
 pkgname=heroku-cli
-pkgver=7.36.3
+pkgver=7.38.1
 _builddir=cli-${pkgver}
 pkgrel=1
 pkgdesc="a tool for creating and managing Heroku apps from the command line"
@@ -14,8 +14,8 @@ makedepends=('npm')
 optdepends=('git: Deploying to Heroku')
 conflicts=('heroku-client-standalone' 'heroku-toolbelt' 'ruby-heroku')
 source=("https://registry.npmjs.org/heroku/-/heroku-$pkgver.tgz")
-sha256sums=('2f55c1482fd0a195ce3ab3e65547910069543bf6f59c3033e8dc775174ed88fb')
-sha512sums=('14112ae52eb58ff98285dd6b4bf1117af7ad981b33fd9c26af58733848ae0f4f4c2047a72bbc6414d5a07c7f17c97eacbefa9a459714c6a7511e5e72b797943d')
+sha256sums=('2ddbc5c53fbb114897bcc0008a11bd8f2abcc744d0365f1c4a77f199b1bda9d5')
+sha512sums=('655e8b1d45d36deddbd2ef1c10307fed26678d45f3d3fb2531f9997cf4413211b0e0e1a3b1ca61a0cacb030ceb6df1dff171551feaba7cc7077f203b594d8ff8')
 noextract=("heroku-$pkgver.tgz")
 options=('!strip')
 


### PR DESCRIPTION
Change to the newest heroku-cli version (7.38.1).
All checksum revised, and installation passed.