### PR TITLE
Make some small tweaks to the Heroku package

### DIFF
--- a/heroku-cli/PKGBUILD
+++ b/heroku-cli/PKGBUILD
@@ -20,7 +20,7 @@ noextract=("heroku-$pkgver.tgz")
 options=('!strip')
 
 package() {
-  npm install -g --no-progress --user root --prefix "$pkgdir/usr" heroku-$pkgver.tgz
+  npm install -g --no-progress --user root --prefix "$pkgdir/usr" --cache "$srcdir/npm-cache" heroku-$pkgver.tgz
   mkdir -p "$pkgdir/usr/share/licenses/$pkgname"
   ln -s "../../../lib/node_modules/heroku/LICENSE" "$pkgdir/usr/share/licenses/$pkgname"
 

--- a/heroku-cli/PKGBUILD
+++ b/heroku-cli/PKGBUILD
@@ -20,7 +20,7 @@ noextract=("heroku-$pkgver.tgz")
 options=('!strip')
 
 package() {
-  npm install -g --user root --prefix "$pkgdir/usr" heroku-$pkgver.tgz
+  npm install -g --no-progress --user root --prefix "$pkgdir/usr" heroku-$pkgver.tgz
   mkdir -p "$pkgdir/usr/share/licenses/$pkgname"
   ln -s "../../../lib/node_modules/heroku/LICENSE" "$pkgdir/usr/share/licenses/$pkgname"
 

--- a/heroku-cli/PKGBUILD
+++ b/heroku-cli/PKGBUILD
@@ -26,4 +26,7 @@ package() {
 
   # npm makes some directories world writable
   find "$pkgdir/usr" -type d -exec chmod 755 '{}' +
+
+  find "$pkgdir" -name package.json -print0 | xargs -r -0 sed -i '/_where/d'
+  sed -i "/$(echo $srcdir | sed 's_/_\\/_g')/d" "$pkgdir/usr/lib/node_modules/heroku/package.json"
 }


### PR DESCRIPTION
This makes three small tweaks to the Heroku package:

1. Disable the progress bar during dependency installation. The progress bar isn't necessary when creating a package and has been the source of significant slowdown in the past.
2. Remove all references to the `$srcdir` and `$pkgdir` directories in the packaged files. These are all internal references for Node that aren't necessary so we shouldn't leave them hanging behind.
3. Use a local cache directory for NPM to prevent pollution of the builder's `$HOME` directory.

None of these are dealbreakers but they were papercuts so I thought I'd help fix them.