### PR TITLE
Build issues for heroku-cli/7.50.0

### DIFF
--- a/heroku-cli/.SRCINFO
+++ b/heroku-cli/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = heroku-cli
 	pkgdesc = CLI to manage Heroku apps and services with forced auto-update removed
-	pkgver = 7.50.0
+	pkgver = 7.51.0
 	pkgrel = 1
 	url = https://devcenter.heroku.com/articles/heroku-cli
 	arch = any
@@ -9,6 +9,7 @@ pkgbase = heroku-cli
 	makedepends = npm
 	makedepends = yarn
 	makedepends = perl
+	makedepends = git
 	depends = nodejs
 	optdepends = git: Deploying to Heroku
 	provides = heroku
@@ -18,9 +19,9 @@ pkgbase = heroku-cli
 	conflicts = heroku-toolbelt
 	conflicts = ruby-heroku
 	options = !strip
-	source = https://github.com/heroku/cli/archive/v7.50.0.tar.gz
-	sha256sums = 0a4f5e92b93248443c188a261b6f5179e800ad325856dccaca22e42caebcccd4
-	sha512sums = d5d80ba4439407b75efa7dffff031a4112336de4bab953141ee399e1861275d8b8bf11fcb4da370d6f211aaf15ce4ef8df4d4470ab20c8449accc4410f0f24b6
+	source = git+https://github.com/heroku/cli.git#commit=b07fb744b68993c2b480f155ef1b4fdd509e77e4
+	sha256sums = SKIP
+	sha512sums = SKIP
 
 pkgname = heroku-cli
 


### PR DESCRIPTION
As mentioned in my [AUR comment](https://aur.archlinux.org/packages/heroku-cli#comment-795008), I've been having issues building heroku-cli/7.50.0. I tried building in a clean chroot, but the PKGBUILD, as it was written, didn't allow that.

To fix this, I had to rename `append_path` to `_append_path`, as per the [Arch packing guidelines](https://wiki.archlinux.org/index.php/Arch_package_guidelines#Package_etiquette). I also had to switch to git source, as it seems the build process assumes that it is running on a git repo (it's tried to run `git rev-parse --short HEAD`).

I've also fixed the namcap warnings that came from `package()`.