### PR TITLE
fix: add missing npm dependency to use npx

### DIFF
--- a/heroku-cli/.SRCINFO
+++ b/heroku-cli/.SRCINFO
@@ -9,6 +9,7 @@ pkgbase = heroku-cli
 	makedepends = yarn
 	makedepends = perl
 	makedepends = git
+	makedepends = npm
 	depends = nodejs
 	optdepends = git: Deploying to Heroku
 	provides = heroku

--- a/heroku-cli/PKGBUILD
+++ b/heroku-cli/PKGBUILD
@@ -13,7 +13,7 @@ arch=('any')
 url="https://devcenter.heroku.com/articles/heroku-cli"
 license=('custom' 'ISC')
 depends=('nodejs')
-makedepends=('yarn' 'perl' 'git')
+makedepends=('yarn' 'perl' 'git' 'npm')
 optdepends=('git: Deploying to Heroku')
 conflicts=('heroku-cli-bin' 'heroku-client-standalone' 'heroku-toolbelt' 'ruby-heroku')
 source=("git+https://github.com/heroku/cli.git#commit=${_commit_id}")


### PR DESCRIPTION
Last commit (42048a10a1dcaf3a086dcff7b5a0f2fec9de1f42) mistakenly removed `npm` dependency with the assumption it was only used by its own `npm` binary, but it was also being used by `npx` in the build process.

This re-introduces npm as a dependency. Alternatively we could simply not use `npx`, but this is a quick fix.