### PR TITLE
Update heroku-cli to v7.66.4

### DIFF
--- a/heroku-cli/.SRCINFO
+++ b/heroku-cli/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = heroku-cli
 	pkgdesc = CLI to manage Heroku apps and services with forced auto-update removed
-	pkgver = 7.62.0
+	pkgver = 7.66.4
 	pkgrel = 1
 	url = https://devcenter.heroku.com/articles/heroku-cli
 	arch = any
@@ -19,7 +19,7 @@ pkgbase = heroku-cli
 	conflicts = heroku-toolbelt
 	conflicts = ruby-heroku
 	options = !strip
-	source = git+https://github.com/heroku/cli.git#commit=13db7c5e684c5c44682a5115b9a29632a46fb69c
+	source = git+https://github.com/heroku/cli.git#tag=v7.66.4
 	sha256sums = SKIP
 	sha512sums = SKIP
 

--- a/heroku-cli/PKGBUILD
+++ b/heroku-cli/PKGBUILD
@@ -3,9 +3,8 @@
 # Github Contributors: https://github.com/SampsonCrowley/arch_packages/contributors.md
 
 pkgname=heroku-cli
-pkgver=7.62.0
+pkgver=7.66.4
 pkgrel=1
-_commit_id="13db7c5e684c5c44682a5115b9a29632a46fb69c"
 pkgdesc="CLI to manage Heroku apps and services with forced auto-update removed"
 arch=('any')
 url="https://devcenter.heroku.com/articles/heroku-cli"
@@ -14,7 +13,7 @@ depends=('nodejs')
 makedepends=('yarn' 'perl' 'git' 'npm')
 optdepends=('git: Deploying to Heroku')
 conflicts=('heroku-cli-bin' 'heroku-client-standalone' 'heroku-toolbelt' 'ruby-heroku')
-source=("git+https://github.com/heroku/cli.git#commit=${_commit_id}")
+source=("git+https://github.com/heroku/cli.git#tag=v${pkgver}")
 sha256sums=('SKIP')
 sha512sums=('SKIP')
 options=('!strip')


### PR DESCRIPTION
@SampsonCrowley This updates `heroku-cli` to version 7.66.4. This supersedes #16. Further, I've changed the PKGBUILD to use tags instead of commit IDs, which should make it easier to update versions.